### PR TITLE
SAS-143 Fixed lines to add src path in the imports

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,7 +27,7 @@ repos:
     rev: 3.9.2
     hooks:
     -   id: flake8
-        args: [--ignore=E501, --max-line-length=88, --extend-ignore=E203, --extend-ignore=W503]
+        args: [--ignore=E501, --max-line-length=88, --extend-ignore=E203, --extend-ignore=W503, --extend-ignore=E402]
         language_version: python3
 
 -   repo: https://github.com/asottile/reorder_python_imports

--- a/tests/card_database.py
+++ b/tests/card_database.py
@@ -3,6 +3,11 @@ import os
 import sys
 import unittest
 
+# Add src to path
+current_dir = os.path.dirname(os.path.realpath(__file__))
+src_dir = os.path.join(current_dir, "..", "src")
+sys.path.append(src_dir)
+
 from core.card import add_available_deck_to_card
 from core.card import add_disposable_deck_to_card
 from core.card import add_player_to_card
@@ -21,11 +26,6 @@ from models.game import Game
 from models.game import Player
 from pony.orm import commit
 from pony.orm import db_session
-
-# Add src to path
-current_dir = os.path.dirname(os.path.realpath(__file__))
-src_dir = os.path.join(current_dir, "..", "src")
-sys.path.append(src_dir)
 
 
 class TestCardDatabase(unittest.TestCase):


### PR DESCRIPTION
Fixed card database tests. The lines of adding a src path must to be before the imports (add ignore of requisit of pre-commit that can't let do that)