### PR TITLE
SAS 360 - Implementar método para saber vecinos vivos de un player en una partida

### DIFF
--- a/src/core/player.py
+++ b/src/core/player.py
@@ -29,3 +29,43 @@ def create_player(
     )
     commit()
     return player
+
+
+@db_session
+def get_alive_neighbors(id_game: int, id_player: int):
+    """Return the list of alive neighbors of a player."""
+    if not Game.exists(id=id_game):
+        raise ValueError(f"Game with id {id_game} doesn't exist")
+    if not Player.exists(id=id_player):
+        raise ValueError(f"Player with id {id_player} doesn't exist")
+
+    player = Player[id_player]
+    current_position = player.round_position
+
+    player_list = list(Game[id_game].players)
+    player_list.sort(key=lambda x: x.round_position)
+
+    cnt_players = len(player_list)
+
+    neighbor_list = []
+
+    for direction in [-1, 1]:
+        neighbor_position = current_position
+        break_condition = False
+
+        while (
+            neighbor_position is current_position
+            or not player_list[neighbor_position - 1].alive
+        ):
+            neighbor_position = (
+                (neighbor_position - 1) + direction + cnt_players
+            ) % cnt_players + 1
+
+            if neighbor_position == current_position:
+                break_condition = True
+                break
+
+        if not break_condition:
+            neighbor_list.append(player_list[neighbor_position - 1].id)
+
+    return neighbor_list

--- a/tests/test_core_player.py
+++ b/tests/test_core_player.py
@@ -1,4 +1,5 @@
 """Module to test the core.player module."""
+import pytest
 from pony.orm import commit
 from pony.orm import db_session
 
@@ -141,3 +142,13 @@ class TestGetAliveNeighbors:
         assert get_alive_neighbors(1, 2 * 10) == []
         assert get_alive_neighbors(1, 2 * 11) == []
         assert get_alive_neighbors(1, 2 * 12) == []
+
+    def test_get_alive_neighbors_with_invalid_game_id(self):
+        """Test get_alive_neighbors with invalid game id."""
+        with pytest.raises(ValueError):
+            get_alive_neighbors(2, 2 * 1)
+
+    def test_get_alive_neighbors_with_invalid_player_id(self):
+        """Test get_alive_neighbors with invalid player id."""
+        with pytest.raises(ValueError):
+            get_alive_neighbors(1, 2 * 13)

--- a/tests/test_core_player.py
+++ b/tests/test_core_player.py
@@ -1,0 +1,143 @@
+"""Module to test the core.player module."""
+from pony.orm import commit
+from pony.orm import db_session
+
+from . import clean_db
+from . import Game
+from . import get_alive_neighbors
+from . import Player
+
+
+class TestGetAliveNeighbors:
+    """Test the get_alive_neighbors function."""
+
+    @classmethod
+    def setup_class(cls):
+        """Setup class."""
+        clean_db()
+
+    @classmethod
+    def teardown_class(cls):
+        """Teardown class."""
+        clean_db()
+
+    @db_session
+    def setup_method(self):
+        """Setup method."""
+        Game(id=1, current_phase="Draw")
+        for i in range(1, 13):
+            Player(
+                id=2 * i,
+                name=f"Player{i}",
+                round_position=i,
+                game=Game[1],
+                alive=True,
+            )
+
+    @db_session
+    def teardown_method(self):
+        """Teardown method."""
+        Game[1].delete()
+        for i in range(1, 13):
+            Player[2 * i].delete()
+        commit()
+
+    def test_get_alive_neighbors_all_alive(self):
+        """Test get_alive_neighbors."""
+
+        # Because the players' id's were set with a *2 to check that the position is used and not the id, then the cases will contain that 2*.
+        assert get_alive_neighbors(1, 2 * 1) == [2 * 12, 2 * 2]
+        assert get_alive_neighbors(1, 2 * 2) == [2 * 1, 2 * 3]
+        assert get_alive_neighbors(1, 2 * 3) == [2 * 2, 2 * 4]
+        assert get_alive_neighbors(1, 2 * 4) == [2 * 3, 2 * 5]
+        assert get_alive_neighbors(1, 2 * 5) == [2 * 4, 2 * 6]
+        assert get_alive_neighbors(1, 2 * 6) == [2 * 5, 2 * 7]
+        assert get_alive_neighbors(1, 2 * 7) == [2 * 6, 2 * 8]
+        assert get_alive_neighbors(1, 2 * 8) == [2 * 7, 2 * 9]
+        assert get_alive_neighbors(1, 2 * 9) == [2 * 8, 2 * 10]
+        assert get_alive_neighbors(1, 2 * 10) == [2 * 9, 2 * 11]
+        assert get_alive_neighbors(1, 2 * 11) == [2 * 10, 2 * 12]
+        assert get_alive_neighbors(1, 2 * 12) == [2 * 11, 2 * 1]
+
+    @db_session
+    def test_get_alive_neighbors_with_random_dead_players(self):
+        """Test get_alive_neighbors with random dead players."""
+
+        Player[2 * 1].alive = False
+        Player[2 * 5].alive = False
+        Player[2 * 11].alive = False
+
+        assert get_alive_neighbors(1, 2 * 1) == [2 * 12, 2 * 2]
+        assert get_alive_neighbors(1, 2 * 2) == [2 * 12, 2 * 3]
+        assert get_alive_neighbors(1, 2 * 3) == [2 * 2, 2 * 4]
+        assert get_alive_neighbors(1, 2 * 4) == [2 * 3, 2 * 6]
+        assert get_alive_neighbors(1, 2 * 5) == [2 * 4, 2 * 6]
+        assert get_alive_neighbors(1, 2 * 6) == [2 * 4, 2 * 7]
+        assert get_alive_neighbors(1, 2 * 7) == [2 * 6, 2 * 8]
+        assert get_alive_neighbors(1, 2 * 8) == [2 * 7, 2 * 9]
+        assert get_alive_neighbors(1, 2 * 9) == [2 * 8, 2 * 10]
+        assert get_alive_neighbors(1, 2 * 10) == [2 * 9, 2 * 12]
+        assert get_alive_neighbors(1, 2 * 11) == [2 * 10, 2 * 12]
+        assert get_alive_neighbors(1, 2 * 12) == [2 * 10, 2 * 2]
+
+    @db_session
+    def test_get_alive_neighbors_with_one_alive_player(self):
+        """Test get_alive_neighbors with only one alive player."""
+
+        for i in range(1, 13):
+            if i != 6:
+                Player[2 * i].alive = False
+
+        assert get_alive_neighbors(1, 2 * 1) == [2 * 6, 2 * 6]
+        assert get_alive_neighbors(1, 2 * 2) == [2 * 6, 2 * 6]
+        assert get_alive_neighbors(1, 2 * 3) == [2 * 6, 2 * 6]
+        assert get_alive_neighbors(1, 2 * 4) == [2 * 6, 2 * 6]
+        assert get_alive_neighbors(1, 2 * 5) == [2 * 6, 2 * 6]
+        assert get_alive_neighbors(1, 2 * 6) == []
+        assert get_alive_neighbors(1, 2 * 7) == [2 * 6, 2 * 6]
+        assert get_alive_neighbors(1, 2 * 8) == [2 * 6, 2 * 6]
+        assert get_alive_neighbors(1, 2 * 9) == [2 * 6, 2 * 6]
+        assert get_alive_neighbors(1, 2 * 10) == [2 * 6, 2 * 6]
+        assert get_alive_neighbors(1, 2 * 11) == [2 * 6, 2 * 6]
+        assert get_alive_neighbors(1, 2 * 12) == [2 * 6, 2 * 6]
+
+    @db_session
+    def test_get_alive_neighbors_with_two_alive_players(self):
+        """Test get_alive_neighbors with two alive players."""
+
+        for i in range(1, 13):
+            if i != 6 and i != 7:
+                Player[2 * i].alive = False
+
+        assert get_alive_neighbors(1, 2 * 1) == [2 * 7, 2 * 6]
+        assert get_alive_neighbors(1, 2 * 2) == [2 * 7, 2 * 6]
+        assert get_alive_neighbors(1, 2 * 3) == [2 * 7, 2 * 6]
+        assert get_alive_neighbors(1, 2 * 4) == [2 * 7, 2 * 6]
+        assert get_alive_neighbors(1, 2 * 5) == [2 * 7, 2 * 6]
+        assert get_alive_neighbors(1, 2 * 6) == [2 * 7, 2 * 7]
+        assert get_alive_neighbors(1, 2 * 7) == [2 * 6, 2 * 6]
+        assert get_alive_neighbors(1, 2 * 8) == [2 * 7, 2 * 6]
+        assert get_alive_neighbors(1, 2 * 9) == [2 * 7, 2 * 6]
+        assert get_alive_neighbors(1, 2 * 10) == [2 * 7, 2 * 6]
+        assert get_alive_neighbors(1, 2 * 11) == [2 * 7, 2 * 6]
+        assert get_alive_neighbors(1, 2 * 12) == [2 * 7, 2 * 6]
+
+    @db_session
+    def test_get_alive_neighbors_with_no_alive_player(self):
+        """Test get_alive_neighbors with no alive player."""
+
+        for i in range(1, 13):
+            Player[2 * i].alive = False
+
+        assert get_alive_neighbors(1, 2 * 1) == []
+        assert get_alive_neighbors(1, 2 * 2) == []
+        assert get_alive_neighbors(1, 2 * 3) == []
+        assert get_alive_neighbors(1, 2 * 4) == []
+        assert get_alive_neighbors(1, 2 * 5) == []
+        assert get_alive_neighbors(1, 2 * 6) == []
+        assert get_alive_neighbors(1, 2 * 7) == []
+        assert get_alive_neighbors(1, 2 * 8) == []
+        assert get_alive_neighbors(1, 2 * 9) == []
+        assert get_alive_neighbors(1, 2 * 10) == []
+        assert get_alive_neighbors(1, 2 * 11) == []
+        assert get_alive_neighbors(1, 2 * 12) == []


### PR DESCRIPTION
## Descripción

Se puede ver en el siguiente [enlace](https://ingsoft-grupito.atlassian.net/jira/software/projects/SAS/boards/1?assignee=62fea443eec8d4a478d5100f&selectedIssue=SAS-360) (tarjeta de Jira)

## Criterios de aceptación

- En caso que el id_game y/o id_player sean inválidos (no existen o el player está muerto), levantar excepción de tipo ValueError

- El funcionamiento que debe tener este método es devolver los vecinos vivos del player en esa partida (id_game). Se devuelve una lista de a lo sumo 2 elementos.

  - Se deben testear casos con jugadores muertos

  - Se deben testear casos extremos (que pase de position 1 a 7 por ejemplo)

  - Se deben testear casos donde la lista sea vacía (cero o un solo player vivo) o donde tenga un solo elemento (dos player vivos)
